### PR TITLE
policyErrors have been expanded to auditResults

### DIFF
--- a/warden/cmd/errors-policy.go
+++ b/warden/cmd/errors-policy.go
@@ -1,7 +1,5 @@
 package cmd
 
-import "fmt"
-
 const (
 	ERR_ACCESS_EXTRA      = "The user/team '%s' is present and shouldn't be."
 	ERR_ACCESS_MISSING    = "The user/team %s is not defined."
@@ -16,15 +14,3 @@ const (
 	ERR_CO_MISSING        = "The CODEOWNERS file is missing."
 	ERR_CO_SYNTAX         = "The CODEOWNERS file has syntax errors:\n%s"
 )
-
-// Represents a error when applying a policy, with contextual information.
-type policyError struct {
-	repository *wardenRepo
-	message    string
-	values     []any
-}
-
-// Properly print out a policy error.
-func (this policyError) Error() string {
-	return fmt.Sprintf(this.message, this.values...)
-}

--- a/warden/cmd/results.go
+++ b/warden/cmd/results.go
@@ -1,0 +1,44 @@
+package cmd
+
+import "fmt"
+
+// an enum for what an auditResult can be
+type auditResultType int
+
+const (
+	RESULT_DEBUG auditResultType = iota
+	RESULT_INFO
+	RESULT_WARNING
+	RESULT_ERROR
+)
+
+// auditResults are what a policy audit can return. These can be notes, debug information, warnings, and most importantly, errors.
+type auditResult struct {
+	repository *wardenRepo
+	resultType auditResultType
+	message    string
+	values     []any
+}
+
+// Properly print out a result
+func (this auditResult) String() string {
+	return fmt.Sprintf(this.message, this.values...)
+}
+
+// the list of results returned from the audit
+type auditResults []auditResult
+
+// adds a new result
+func (this *auditResults) add(repo *wardenRepo, resultType auditResultType, message string, values ...any) {
+	*this = append(*this, auditResult{
+		repo,
+		resultType,
+		message,
+		values,
+	})
+}
+
+// combine two auditResults together
+func (this *auditResults) merge(results auditResults) {
+	*this = append(*this, results...)
+}


### PR DESCRIPTION
This allows an audit from returning just errors to more types such as info, debug, and warnings.